### PR TITLE
Fix dependencies in requirements.txt to support internal markdown links

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -79,4 +79,4 @@ In particular:
 * OCDS for PPP data can be converted into spreadsheet formats for detailed analysis;
 * Any third-party can build an interface using the OCDS for PPPs standard;
 
-You can explore a [preview of OCDS show with example data](_static/ocds-show/?load=/_static/full.json).
+You can explore a [preview of OCDS show with example data](/_static/ocds-show/?load=/_static/full.json).

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -17,7 +17,7 @@ The extended OCDS for PPPs schema provides all the elements covered by the [Worl
 
 To produce and validate OCDS for PPPs data, create an [OCDS 1.1 file](http://standard.open-contracting.org/latest/en/schema/), and declare the consolidated OCDS for PPPs extensions as part of a release or record package.
 
-A compiled OCDS for PPPs schema, with the extensions applied, is also  [available to download](/_static/ppp-extension.json), and a [full reference table is provided](/reference/schema.html).
+A compiled OCDS for PPPs schema, with the extensions applied, is also  [available to download](../_static/ppp-extension.json), and a [full reference table is provided](reference/schema.md).
 
 ## Who is this for?
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
-Sphinx==1.5.3
+# sphinx commit pinned from stable branch
+-e git+https://github.com/sphinx-doc/sphinx.git@95583428f5d2fd93c9def52bba028d2cefd930d5#egg=Sphinx
+Markdown==2.6.5
 sphinx-intl==0.9.9
 transifex-client==0.12.4
 sphinx-rtd-theme==0.2.4
 # recommonmark commit pinned from master branch
--e git+https://github.com/rtfd/recommonmark.git@50be4978d7d91d0b8a69643c63450c8cd92d1212#egg=recommonmark
+-e git+https://github.com/rtfd/recommonmark.git@b70d5f52245d6714054e2d8f871ac6449bd980f8#egg=recommonmark
 ## The following requirements were added by pip freeze:
 alabaster==0.7.10
 appdirs==1.4.3


### PR DESCRIPTION
@duncandewhurst the problem was the version of Sphinx we were using, I think it it doesn't support that feature from markdown! I've updated to use the same Sphinx version we use in [requirements.txt](https://github.com/open-contracting/standard/blob/1.0-dev/requirements.txt) in the OCDS standard repo  