### PR TITLE
[#83] add a tip about viewing json in browser

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -41,7 +41,7 @@ In the record within OCDS show:
 
 Use the 'text input' button to see (and adapt) the JSON data which generates this view.
 
-Use a web browser addon for a more user friendly preview of the json files. Install [JSONView for Chrome](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc) or [JSONView for Firefox](https://addons.mozilla.org/en-us/firefox/addon/jsonview/).
+Use a web browser addon for a more user friendly preview of the JSON files. You can install [JSONView for Chrome](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc), [JSONView for Firefox](https://addons.mozilla.org/en-us/firefox/addon/jsonview/) or [JSONView for Safari](https://safari-extensions.apple.com/details/?id=com.dcrousso.jsonview-safari-Q5M4T22BE9) 
 
 Using the open source [OCDS Show framework](https://github.com/open-contracting/ocds-show/tree/ppp) alternative presentations of data can be prepared.
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -41,5 +41,7 @@ In the record within OCDS show:
 
 Use the 'text input' button to see (and adapt) the JSON data which generates this view.
 
+Use a web browser addon for a more user friendly preview of the json files. Install [JSONView for Chrome](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc) or [JSONView for Firefox](https://addons.mozilla.org/en-us/firefox/addon/jsonview/).
+
 Using the open source [OCDS Show framework](https://github.com/open-contracting/ocds-show/tree/ppp) alternative presentations of data can be prepared.
 


### PR DESCRIPTION
I provided links to JSONView (chrome and firefox) ... easy to remember name for both browsers.

Most people have chrome and firefox, so i didn't provide text for IE or Opera etc.