### PR TITLE
Add a themed 404 page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,5 @@
+# 404 Not found
+
+We couldn't find the page you were looking for in this version of the documentation.
+
+Try looking from the [home page](index.md), or use the search or navigation on the left hand side of the page.


### PR DESCRIPTION
Same as for the standard docs https://github.com/open-contracting/standard/blob/1.1-dev/standard/docs/en/404.md

Currently this looks like http://standard.open-contracting.org/profiles/ppp/latest/en/notexist