### PR TITLE
fix broken link to schema

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,6 +1,6 @@
 # Full schema reference
 
-The table below contains all possible fields provided by the [OCDS for PPPs schema](../../../_static/ppp-release-schema.json)
+The table below contains all possible fields provided by the [OCDS for PPPs schema](../../../../_static/ppp-release-schema.json)
 
 ```eval_rst
 .. jsonschema:: ../_static/ppp-release-schema.json


### PR DESCRIPTION
I think this was broken before the recent deploy (at least the link wasn't changed and the resource hasn't been moved)